### PR TITLE
feat: add embedding progress tracking and uuid-based document binding

### DIFF
--- a/main.py
+++ b/main.py
@@ -373,8 +373,9 @@ def replace_images_in_pdf(pdf_path: str, original_images: List[str],
         return False
 
 
-def embed_watermark_to_docx(docx_path: str, qr_path: str = None, output_path: str = None, 
-                          qr_data: str = None, security_config: dict = None) -> dict:
+def embed_watermark_to_docx(docx_path: str, qr_path: str = None, output_path: str = None,
+                          qr_data: str = None, security_config: dict = None,
+                          progress_callback=None) -> dict:
     """
     Process a docx document to add QR watermarks to all images.
 
@@ -451,6 +452,9 @@ def embed_watermark_to_docx(docx_path: str, qr_path: str = None, output_path: st
         print(f"[*] Mengekstrak gambar dari dokumen: {docx_path}")
         extracted_images = extract_images_from_docx(docx_path, temp_dir)
 
+        if progress_callback:
+            progress_callback(0, len(extracted_images))
+
         if not extracted_images:
             print("[!] Dokumen ini tidak mengandung gambar")
             # Clean up temporary directory
@@ -499,6 +503,9 @@ def embed_watermark_to_docx(docx_path: str, qr_path: str = None, output_path: st
                     "original": f"{public_dir_name}/{original_public_name}",
                     "watermarked": f"{public_dir_name}/{watermarked_public_name}"
                 })
+
+                if progress_callback:
+                    progress_callback(i + 1, len(extracted_images))
                 
             except Exception as e:
                 print(f"[!] Gagal watermark gambar {img_path}: {str(e)}")
@@ -543,8 +550,9 @@ def embed_watermark_to_docx(docx_path: str, qr_path: str = None, output_path: st
 
         # Return success status and image info
         result = {
-            "success": success, 
+            "success": success,
             "processed_images": processed_images,
+            "total_images": len(extracted_images),
             "qr_image": f"{public_dir_name}/{qr_public_name}",
             "public_dir": public_dir_name,
             "qr_info": qr_info,
@@ -576,7 +584,8 @@ def embed_watermark_to_docx(docx_path: str, qr_path: str = None, output_path: st
 
 
 def embed_watermark_to_pdf(pdf_path: str, qr_path: str = None, output_path: str = None,
-                         qr_data: str = None, security_config: dict = None) -> dict:
+                         qr_data: str = None, security_config: dict = None,
+                         progress_callback=None) -> dict:
     """
     Process a PDF document to add QR watermarks to all images.
 
@@ -652,6 +661,9 @@ def embed_watermark_to_pdf(pdf_path: str, qr_path: str = None, output_path: str 
         print(f"[*] Mengekstrak gambar dari PDF: {pdf_path}")
         extracted_images = extract_images_from_pdf(pdf_path, temp_dir)
 
+        if progress_callback:
+            progress_callback(0, len(extracted_images))
+
         if not extracted_images:
             print("[!] PDF ini tidak mengandung gambar")
             # Clean up temporary directory
@@ -695,6 +707,9 @@ def embed_watermark_to_pdf(pdf_path: str, qr_path: str = None, output_path: str 
                     "original": f"{public_dir_name}/{original_public_name}",
                     "watermarked": f"{public_dir_name}/{watermarked_public_name}"
                 })
+
+                if progress_callback:
+                    progress_callback(i + 1, len(extracted_images))
                 
             except Exception as e:
                 print(f"[!] Gagal watermark gambar {img_path}: {str(e)}")
@@ -739,8 +754,9 @@ def embed_watermark_to_pdf(pdf_path: str, qr_path: str = None, output_path: str 
 
         # Return success status and image info
         result = {
-            "success": success, 
+            "success": success,
             "processed_images": processed_images,
+            "total_images": len(extracted_images),
             "qr_image": f"{public_dir_name}/{qr_public_name}",
             "public_dir": public_dir_name,
             "qr_info": qr_info,

--- a/secure_qr_utils.py
+++ b/secure_qr_utils.py
@@ -64,7 +64,14 @@ class SecureQRGenerator:
             
             # Generate document fingerprint
             fingerprint = self.binder.generate_document_fingerprint(document_path)
-            
+
+            # Ensure this document and QR data are not already bound
+            if self.storage.load_binding_record(fingerprint["document_id"]):
+                raise DocumentSecurityError("A QR code has already been generated for this document")
+            existing_qr = self.storage.find_record_by_qr_data(data)
+            if existing_qr and existing_qr.get("document_fingerprint", {}).get("document_id") != fingerprint["document_id"]:
+                raise DocumentSecurityError("This QR data is already bound to another document")
+
             # Generate binding token
             binding_token = self.binder.generate_binding_token(
                 fingerprint, data, expiry_hours
@@ -199,7 +206,14 @@ class SecureQRGenerator:
             
             # Generate document fingerprint
             fingerprint = self.binder.generate_document_fingerprint(document_path)
-            
+
+            # Ensure this document and QR data are not already bound
+            if self.storage.load_binding_record(fingerprint["document_id"]):
+                raise DocumentSecurityError("A QR code has already been generated for this document")
+            existing_qr = self.storage.find_record_by_qr_data(qr_data)
+            if existing_qr and existing_qr.get("document_fingerprint", {}).get("document_id") != fingerprint["document_id"]:
+                raise DocumentSecurityError("This QR data is already bound to another document")
+
             # Generate binding token
             binding_token = self.binder.generate_binding_token(
                 fingerprint, qr_data, expiry_hours

--- a/static/css/modern-layout.css
+++ b/static/css/modern-layout.css
@@ -1376,17 +1376,18 @@
 
 /* Progress bar enhancements */
 .progress-bar {
-    background: #f1f5f9;
+    background: #e2e8f0;
     border-radius: 8px;
     overflow: hidden;
-    height: 8px;
+    height: 12px;
     margin-bottom: 1rem;
 }
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #3b82f6, #60a5fa);
+    background: linear-gradient(90deg, #3b82f6, #06b6d4);
     border-radius: 8px;
+    box-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
     transition: width 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- expose /analyze_document API to count images before embedding
- track server-side embedding progress and poll via /progress
- enhance embed UI with real-time progress bar and improved styling
- derive stable UUIDs from document content and block QR reuse across documents

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689211c05540833390fa91f21575c256