### PR TITLE
Expose image counts during embedding

### DIFF
--- a/app.py
+++ b/app.py
@@ -1140,19 +1140,21 @@ def embed_document_route():
                 process_result = embed_watermark_to_docx(doc_temp_path, qr_temp_path, stego_doc_output_path)
             else:  # is_pdf
                 process_result = embed_watermark_to_pdf(doc_temp_path, qr_temp_path, stego_doc_output_path)
-            
+
             # Get processed images info if available
             processed_images = []
             qr_image_url = ""
             public_dir = ""
             qr_info = None
-            
+            total_images = 0
+
             if isinstance(process_result, dict) and process_result.get("success"):
                 processed_images = process_result.get("processed_images", [])
                 qr_image_url = process_result.get("qr_image", "")
                 public_dir = process_result.get("public_dir", "")
                 qr_info = process_result.get("qr_info", None)
-                print(f"[*] Mendapatkan {len(processed_images)} gambar yang diproses")
+                total_images = process_result.get("total_images", len(processed_images))
+                print(f"[*] Mendapatkan {len(processed_images)} gambar yang diproses dari {total_images} gambar")
             else:
                 print("[!] Tidak mendapatkan detail gambar yang diproses")
         except ValueError as ve:
@@ -1175,6 +1177,7 @@ def embed_document_route():
             qr_image_url = ""
             public_dir = ""
             qr_info = None
+            total_images = 0
         
         # Hitung MSE dan PSNR (only for DOCX, PDF comparison is more complex)
         if is_docx:
@@ -1218,6 +1221,7 @@ def embed_document_route():
             "mse": metrics["mse"],
             "psnr": metrics["psnr"],
             "processed_images": processed_images,
+            "total_images": total_images,
             "qr_image": qr_image_url,
             "public_dir": public_dir,
             "qr_info": qr_info,

--- a/static/js/embed.js
+++ b/static/js/embed.js
@@ -229,6 +229,8 @@ function initQRPreview() {
   const charCount = document.getElementById('charCount');
   const capacityAnalysis = document.getElementById('capacityAnalysis');
 
+  if (!qrDataInput || !charCount || !capacityAnalysis) return;
+
   let previewTimeout;
 
   qrDataInput.addEventListener('input', function () {
@@ -341,6 +343,8 @@ function initSecurityOptions() {
   const securityTitle = document.getElementById('securityTitle');
   const securitySubtitle = document.getElementById('securitySubtitle');
   const securityIcon = document.getElementById('securityIcon');
+
+  if (!securityToggle || !securityConfig || !securityTitle || !securitySubtitle || !securityIcon) return;
 
   securityToggle.addEventListener('change', function () {
     if (this.checked) {
@@ -1337,11 +1341,18 @@ function updateOverviewTab(result) {
 function updateImageStats(result) {
   const totalCount = document.getElementById('totalImagesCount');
   const processedCount = document.getElementById('processedImagesCount');
+  const statsContainer = document.getElementById('embedImageStats');
 
-  if (result.processed_images) {
-    const total = result.processed_images.length;
+  // Determine total images from result.total_images if available
+  const total = typeof result.total_images === 'number'
+    ? result.total_images
+    : (result.processed_images ? result.processed_images.length : 0);
 
-    if (totalCount) totalCount.textContent = total;
-    if (processedCount) processedCount.textContent = total;
+  if (totalCount) totalCount.textContent = total;
+  const processed = result.processed_images ? result.processed_images.length : 0;
+  if (processedCount) processedCount.textContent = processed;
+
+  if (statsContainer && (total > 0 || processed > 0)) {
+    statsContainer.style.display = 'flex';
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -219,6 +219,18 @@
             </div>
         </div>
 
+        <!-- Image Statistics for Embedding -->
+        <div class="image-stats" id="embedImageStats" style="display: none;">
+            <div class="stat-item">
+                <span class="stat-label">Total Gambar:</span>
+                <span class="stat-number" id="totalImagesCount">0</span>
+            </div>
+            <div class="stat-item">
+                <span class="stat-label">Berhasil Diproses:</span>
+                <span class="stat-number" id="processedImagesCount">0</span>
+            </div>
+        </div>
+
         <!-- Process Details -->
         <div class="process-details" id="generateProcess" style="display: none;">
             <div class="details-toggle" onclick="toggleProcessDetails()">
@@ -255,4 +267,5 @@ function toggleProcessDetails() {
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/qr-generator.js') }}"></script>
-{% endblock %} 
+<script src="{{ url_for('static', filename='js/embed.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- track and return total image count during document embedding
- show total and processed image counts in embedding UI
- harden embed scripts with element guards and display stats when available

## Testing
- `python test/test_application.py --test-type lsb` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689218d8d6e48333b87536fc112c8a82