### PR TITLE
Expose image counts during embedding

### DIFF
--- a/static/js/embed.js
+++ b/static/js/embed.js
@@ -229,6 +229,8 @@ function initQRPreview() {
   const charCount = document.getElementById('charCount');
   const capacityAnalysis = document.getElementById('capacityAnalysis');
 
+  if (!qrDataInput || !charCount || !capacityAnalysis) return;
+
   let previewTimeout;
 
   qrDataInput.addEventListener('input', function () {
@@ -341,6 +343,8 @@ function initSecurityOptions() {
   const securityTitle = document.getElementById('securityTitle');
   const securitySubtitle = document.getElementById('securitySubtitle');
   const securityIcon = document.getElementById('securityIcon');
+
+  if (!securityToggle || !securityConfig || !securityTitle || !securitySubtitle || !securityIcon) return;
 
   securityToggle.addEventListener('change', function () {
     if (this.checked) {
@@ -1337,11 +1341,18 @@ function updateOverviewTab(result) {
 function updateImageStats(result) {
   const totalCount = document.getElementById('totalImagesCount');
   const processedCount = document.getElementById('processedImagesCount');
+  const statsContainer = document.getElementById('embedImageStats');
 
-  if (result.processed_images) {
-    const total = result.processed_images.length;
+  // Determine total images from result.total_images if available
+  const total = typeof result.total_images === 'number'
+    ? result.total_images
+    : (result.processed_images ? result.processed_images.length : 0);
 
-    if (totalCount) totalCount.textContent = total;
-    if (processedCount) processedCount.textContent = total;
+  if (totalCount) totalCount.textContent = total;
+  const processed = result.processed_images ? result.processed_images.length : 0;
+  if (processedCount) processedCount.textContent = processed;
+
+  if (statsContainer && (total > 0 || processed > 0)) {
+    statsContainer.style.display = 'flex';
   }
 }

--- a/static/js/embed.js
+++ b/static/js/embed.js
@@ -1343,16 +1343,17 @@ function updateImageStats(result) {
   const processedCount = document.getElementById('processedImagesCount');
   const statsContainer = document.getElementById('embedImageStats');
 
-  // Determine total images from result.total_images if available
-  const total = typeof result.total_images === 'number'
-    ? result.total_images
-    : (result.processed_images ? result.processed_images.length : 0);
+  // Use provided totals, falling back gracefully when data is missing
+  const total = typeof result.total_images === 'number' ? result.total_images : '-';
+  const processed = Array.isArray(result.processed_images)
+    ? result.processed_images.length
+    : 0;
 
   if (totalCount) totalCount.textContent = total;
-  const processed = result.processed_images ? result.processed_images.length : 0;
   if (processedCount) processedCount.textContent = processed;
 
-  if (statsContainer && (total > 0 || processed > 0)) {
+  // Always display stats container for embedding results
+  if (statsContainer) {
     statsContainer.style.display = 'flex';
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -219,6 +219,18 @@
             </div>
         </div>
 
+        <!-- Image Statistics for Embedding -->
+        <div class="image-stats" id="embedImageStats" style="display: none;">
+            <div class="stat-item">
+                <span class="stat-label">Total Gambar:</span>
+                <span class="stat-number" id="totalImagesCount">0</span>
+            </div>
+            <div class="stat-item">
+                <span class="stat-label">Berhasil Diproses:</span>
+                <span class="stat-number" id="processedImagesCount">0</span>
+            </div>
+        </div>
+
         <!-- Process Details -->
         <div class="process-details" id="generateProcess" style="display: none;">
             <div class="details-toggle" onclick="toggleProcessDetails()">
@@ -255,4 +267,5 @@ function toggleProcessDetails() {
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/qr-generator.js') }}"></script>
-{% endblock %} 
+<script src="{{ url_for('static', filename='js/embed.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- track and return total image count during document embedding
- show total and processed image counts in embedding UI
- harden embed scripts with element guards and display stats when available
- remove subprocess call so embedding uses internal functions directly and improves error handling

## Testing
- `python test/test_application.py --test-type lsb` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689218d8d6e48333b87536fc112c8a82